### PR TITLE
Add probabilistic version of busy beaver

### DIFF
--- a/code/busy-beaver/prob-prog/busy_beaver.py
+++ b/code/busy-beaver/prob-prog/busy_beaver.py
@@ -19,10 +19,11 @@ RULES_5 = {
 }
 
 class TuringMachine:
-    def __init__(self):
+    def __init__(self, rules):
         self.state = 'a'
         self.tape = [0]
         self.head = 0
+        self.rules = rules
 
     def move(self, direction):
         if direction == 'l':
@@ -37,7 +38,7 @@ class TuringMachine:
         
     def act(self):
         current_output = self.tape[self.head]
-        next_rule = RULES_5[self.state][current_output]
+        next_rule = self.rules[self.state][current_output]
         self.state = next_rule[0]
         self.tape[self.head] = next_rule[1]
         self.move(next_rule[2])
@@ -49,5 +50,5 @@ class TuringMachine:
                 break
             self.act()
 
-tm = TuringMachine()
+tm = TuringMachine(RULES_5)
 tm.run()

--- a/code/busy-beaver/prob-prog/probabilistic_busy_beaver.py
+++ b/code/busy-beaver/prob-prog/probabilistic_busy_beaver.py
@@ -1,0 +1,42 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import torch
+from pyro.infer import EmpiricalMarginal, Importance
+
+class ProbabilisticTuringMachine:
+    def __init__(self):
+        self.state = 'a'
+        self.tape = [0]
+        self.head = 0
+
+    def move(self, direction):
+        if direction == 'l':
+            self.head -=1
+        elif direction == 'r':
+            self.head += 1
+        if self.head < 0:
+            self.tape.insert(0, 0) # insert 0 in beginning of list
+            self.head = 0
+        if self.head >= len(self.tape):
+            self.tape.append(0) # insert 0 at end of list
+        
+    def act(self):
+        self.state = np.random.choice(['a', 'b', 'c', 'd', 'e', 'h'])
+        self.tape[self.head] = 1 # always writes 1
+        self.move('r') # move only in one direction
+
+    def run(self):
+        while True:
+            print(f'STATE: {self.state}, TAPE: {self.tape}, HEAD: {self.head}')
+            if self.state == 'h':
+                break
+            self.act()
+        return torch.tensor(np.sum(self.tape)) # return number of 1's
+            
+def trial():
+    tm = ProbabilisticTuringMachine()
+    return tm.run()
+
+posterior = Importance(trial, guide=None, num_samples=1000)
+marginal = EmpiricalMarginal(posterior.run())
+plt.hist([marginal().item() for _ in range(1000)], bins=100)


### PR DESCRIPTION
Group: Renee Leung (@reneeleung), Julia Schirmeister (@jschirme), Alexander Walker (@AlexanderCWalker)

A probabilistic Turing machine for the busy beaver problem with a simple rule: uniformly select a state (including halt), always write 1, and always move right.
The following is a distribution of the number of 1's after running 1000 trials:
![index](https://user-images.githubusercontent.com/24193128/151675603-1c626a7e-cc27-483a-9ae6-58a25691ed18.png)

